### PR TITLE
Configured ear plugin to remove version numbers

### DIFF
--- a/openwis-dataservice/openwis-dataservice-server/openwis-dataservice-server-ear/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-server/openwis-dataservice-server-ear/pom.xml
@@ -26,8 +26,10 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-ear-plugin</artifactId>
-				<version>2.4.2</version>
+				<version>2.9.1</version>
 				<configuration>
+                    <fileNameMapping>no-version-for-ejb</fileNameMapping>
+
 					<!-- Generate the conf file jboss-app.xml -->
 					<jboss>
 						<version>5</version>

--- a/openwis-management/openwis-management-service/openwis-management-service-ear/pom.xml
+++ b/openwis-management/openwis-management-service/openwis-management-service-ear/pom.xml
@@ -24,8 +24,10 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-ear-plugin</artifactId>
-				<version>2.4.2</version>
+				<version>2.9.1</version>
 				<configuration>
+                    <fileNameMapping>no-version-for-ejb</fileNameMapping>
+
 					<!-- Permet de generer le fichier de configuration jboss-app.xml -->
 					<jboss>
 						<version>5</version>

--- a/openwis-securityservice/openwis-securityservice-usermanagement-server/openwis-securityservice-usermanagement-server-ear/pom.xml
+++ b/openwis-securityservice/openwis-securityservice-usermanagement-server/openwis-securityservice-usermanagement-server-ear/pom.xml
@@ -25,8 +25,10 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-ear-plugin</artifactId>
-				<version>2.4.2</version>
+				<version>2.9.1</version>
 				<configuration>
+                    <fileNameMapping>no-version-for-ejb</fileNameMapping>
+
                     <!-- Generate the conf file jboss-app.xml -->
 					<jboss>
 						<version>5</version>


### PR DESCRIPTION
Configured the ear plugin to remove version numbers from the EJB jar files that make up the ear.  This removes the need to change the SOAP URLs when upgrading the portal.

This required a change to the ear plugin as the previous version did not support the `no-version-for-ejb` file mapping configuration option.
