### PR TITLE
Added the finalName parameter to ensure that openwis-harness-client buil...

### DIFF
--- a/openwis-harness/openwis-harness-client/pom.xml
+++ b/openwis-harness/openwis-harness-client/pom.xml
@@ -13,6 +13,7 @@
 	<name>Openwis Harness client</name>
 
 	<build>
+		<finalName>openwis-harness-client</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.cxf</groupId>


### PR DESCRIPTION
...ds with no version number similar to the rest of the artifacts. This addresses issue #14 ( harness is building with a version number)
