### PR TITLE
Issue 26: GISC cache can not be browsed

### DIFF
--- a/openwis-dataservice/openwis-dataservice-cache/openwis-dataservice-cache-ejb/src/main/java/org/openwis/dataservice/cache/CacheIndexImpl.java
+++ b/openwis-dataservice/openwis-dataservice-cache/openwis-dataservice-cache-ejb/src/main/java/org/openwis/dataservice/cache/CacheIndexImpl.java
@@ -115,7 +115,7 @@ public class CacheIndexImpl implements CacheIndex, ConfigurationInfo {
       filteredBrowseCacheQuery.append("lcf.filename, ");
       filteredBrowseCacheQuery.append("lcf.checksum, ");
       filteredBrowseCacheQuery.append("lcf.received_from_gts, ");
-      filteredBrowseCacheQuery.append("pm.urn, ");
+      filteredBrowseCacheQuery.append("cast(pm.urn as text), ");
       filteredBrowseCacheQuery.append("lcf.insertion_date ");
       filteredBrowseCacheQuery.append("FROM ");
       filteredBrowseCacheQuery.append("(SELECT ");


### PR DESCRIPTION
Modified the query in "CacheIndexImpl.getFilteredBrowseCacheQuery" by
adding an explicit cast of the URN column from citext to text.  This is
to fix a Hibernate mapping problem for the citext column in native
queries.

This is a fix for [Issue 26: GISC cache cannot be browsed](https://github.com/OpenWIS/openwis/issues/26)
