### PR TITLE
Issue 15: Category drop-down in Browse My Metadata (merge to develop)

### DIFF
--- a/openwis-metadataportal/openwis-portal/src/main/webapp/WEB-INF/config-openwis-admin.xml
+++ b/openwis-metadataportal/openwis-portal/src/main/webapp/WEB-INF/config-openwis-admin.xml
@@ -100,13 +100,6 @@
 		<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
 		<!-- Categories                                                    -->
 		<!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-		<service name="xml.category.all" type="xml">
-			<class name=".services.category.All"/>
-			<error id="operation-not-allowed" sheet="error-embedded.xsl" statusCode="403">
-				<xml name="error" file="xml/privileges-error.xml"/>
-			</error>
-		</service>
-
 		<service name="xml.category.get" type="xml">
 			<class name=".services.category.Get"/>
 			<error id="operation-not-allowed" sheet="error-embedded.xsl" statusCode="403">

--- a/openwis-metadataportal/openwis-portal/src/main/webapp/WEB-INF/config-openwis-common.xml
+++ b/openwis-metadataportal/openwis-portal/src/main/webapp/WEB-INF/config-openwis-common.xml
@@ -154,6 +154,16 @@
         </service>
 
         <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <!-- Categories                                                    -->
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+        <service name="xml.category.all" type="xml">
+            <class name=".services.category.All"/>
+            <error id="operation-not-allowed" sheet="error-embedded.xsl" statusCode="403">
+                <xml name="error" file="xml/privileges-error.xml"/>
+            </error>
+        </service>
+
+        <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
         <!-- Login                                                         -->
         <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
         <service name="user.login">

--- a/openwis-metadataportal/openwis-portal/src/main/webapp/WEB-INF/userPortal-profiles.xml
+++ b/openwis-metadataportal/openwis-portal/src/main/webapp/WEB-INF/userPortal-profiles.xml
@@ -124,6 +124,9 @@
 		<allow service="crs.types"/>
 		<allow service="crs.get"/>
 		
+		<!-- Categories -->
+        <allow service="xml.category.all"/>
+
 		<!-- OpenWIS -->
 		<allow service="xml.get.user.backup.centres"/>
 


### PR DESCRIPTION
Moved the "xml.category.all" service from the config-openwis-admin.xml
to config-openwis-common.xml so it can be used in both the user and
admin portal.  Granted the permission for all logged in users to make
use of this service in the user portal.

This is the fix for Issue 15 that is to be merged into develop.
