### PR TITLE
issue22 fix  : Cannot create synchronisation task

### DIFF
--- a/openwis-metadataportal/openwis-portal/src/main/webapp/scripts/Openwis/lib/Openwis/Admin/Synchro/Manage.js
+++ b/openwis-metadataportal/openwis-portal/src/main/webapp/scripts/Openwis/lib/Openwis/Admin/Synchro/Manage.js
@@ -7,7 +7,7 @@ Openwis.Admin.Synchro.Manage = Ext.extend(Ext.Window, {
 		{
 			title: Openwis.i18n('Synchro.Manage.Title'),
 			layout: 'fit',
-			width:450,
+			width:500,
 			height:620,
 			modal: true,
 			border: false,
@@ -81,23 +81,38 @@ Openwis.Admin.Synchro.Manage = Ext.extend(Ext.Window, {
 			this.getDateTo().setValue(Openwis.Utils.Date.ISODateToCalendar(this.config.configuration.dateTo));
 			
 		    var recurrencePeriod = this.config.runMode.recurrentPeriod;
-		    var days = Math.floor(recurrencePeriod / (24 * 3600));
-		    if(days > 0) {
-		        recurrencePeriod %= (24 * 3600);
-		        this.getFrequencyRecurrentDayTextField().setValue(days);
+
+		    var recurrencePeriodHour = recurrencePeriod /3600;
+		    
+		    if ( recurrencePeriodHour % 24 == 0 ) {
+		    	this.getRecurrentProcessingFrequencyCombobox().setValue("DAY");
+		    	this.getRecurrentProcessingNumberField().setValue(recurrencePeriodHour/24);
+		    } else {
+		    	this.getRecurrentProcessingFrequencyCombobox().setValue("HOUR");
+		    	this.getRecurrentProcessingNumberField().setValue(recurrencePeriodHour);
+		    	
 		    }
 		    
-		    var hours = Math.floor(recurrencePeriod / 3600);
-		    if(hours > 0) {
-	            this.getFrequencyRecurrentHourTextField().setValue(hours);
-		        recurrencePeriod %= 3600;
-		    }
-		    
-		    var minuts = recurrencePeriod / 60;
-		    if(minuts > 0) {
-		        this.getFrequencyRecurrentMinuteTextField().setValue(minuts);
-		    }
+//		    var days = Math.floor(recurrencePeriod / (24 * 3600));
+//		    if(days > 0) {
+//		        recurrencePeriod %= (24 * 3600);
+//		        this.getFrequencyRecurrentDayTextField().setValue(days);
+//		    }
+//		    
+//		    var hours = Math.floor(recurrencePeriod / 3600);
+//		    if(hours > 0) {
+//	            this.getFrequencyRecurrentHourTextField().setValue(hours);
+//		        recurrencePeriod %= 3600;
+//		    }
+//		    
+//		    var minuts = recurrencePeriod / 60;
+//		    if(minuts > 0) {
+//		        this.getFrequencyRecurrentMinuteTextField().setValue(minuts);
+//		    }
 			
+		    this.getStartingDateField().setValue(Openwis.Utils.Date.ISODateToCalendar(this.config.runMode.startingDate));
+		    this.getStartingDateTimeField().setValue(Openwis.Utils.Date.ISODateToTime(this.config.runMode.startingDate));
+		    
 			this.getValidationCombobox().setValue(this.config.validationMode);
 	    
     	    if(this.config.backup) {
@@ -246,22 +261,31 @@ Openwis.Admin.Synchro.Manage = Ext.extend(Ext.Window, {
 	 */
 	getFrequencyRunModeCompositeField: function() {
 		if(!this.frequencyRunModeCompositeField) {
-			this.frequencyRunModeCompositeField = new Ext.form.CompositeField({
+			this.frequencyRunModeCompositeField = new Ext.form.FieldSet({
+			//this.frequencyRunModeCompositeField = new Ext.form.CompositeField({
 				name: 'recurrentRunMode',
+				hidden: false,
 				allowBlank:false,
 				fieldLabel: Openwis.i18n('Harvesting.Options.RunMode.Recurrent.Frequency'),
-				width: 350,
+				width: 400,
 				items:
-				[
-				    this.getFrequencyRecurrentDayTextField(),
-				    this.getFrequencyRecurrentHourTextField(),
-				    this.getFrequencyRecurrentMinuteTextField(),
-				    new Ext.Container({
-        				border: false,
-        				html: Openwis.i18n('Harvesting.Options.RunMode.Recurrent.Frequency.Detail'),
-        				cls: 'formItems'
-        			})
-				]
+					[
+					    new Ext.Container({
+	        				border: false,
+	        				html: Openwis.i18n('Harvesting.Options.RunMode.Recurrent.Frequency') + ':',
+	        				cls: 'formItems'
+	        			}),
+					    //this.getFrequencyRecurrentDayTextField(),
+					    //this.getFrequencyRecurrentHourTextField(),
+					    //this.getFrequencyRecurrentMinuteTextField(),
+					    this.getStartingDateCompositeField(),
+					    this.getRecurrentProcessingCompositeField()
+//					    new Ext.Container({
+//	        				border: false,
+//	        				html: Openwis.i18n('Harvesting.Options.RunMode.Recurrent.Frequency.Detail'),
+//	        				cls: 'formItems'
+//	        			})
+					]
 			});
 		}
 		return this.frequencyRunModeCompositeField;
@@ -550,6 +574,121 @@ Openwis.Admin.Synchro.Manage = Ext.extend(Ext.Window, {
 		return this.fetchRemoteInfoAction;
 	},
 	
+	//rajout de l'ihm pour la récurrence
+	getRecurrentProcessingCompositeField: function() {
+	    if(!this.recurrentProcessingCompositeField) {
+    	    this.recurrentProcessingCompositeField = new Ext.form.CompositeField({
+    			width:360,
+    			items: 
+    			[
+    			    {
+    			        xtype: 'container',
+    			        style: {
+    			            paddingLeft: '20px'
+    			        }
+    			    },
+    			    new Ext.form.Label({
+        	    		html : Openwis.i18n('RequestSubscription.SSP.Schedule.RecurrentPeriod.Label')
+        	    	}),
+    				this.getRecurrentProcessingNumberField(),
+    				this.getRecurrentProcessingFrequencyCombobox()
+    			]
+    		});
+		}
+		return this.recurrentProcessingCompositeField;
+	},
+	
+	getRecurrentProcessingNumberField: function() {
+	    if(!this.recurrentProcessingNumberField) {
+    	    this.recurrentProcessingNumberField = new Ext.form.NumberField({
+    	        name: 'frequencyNumber',
+    	        width: 40,
+    	        allowDecimals: false,
+    	        allowNegative: false,
+    	        minValue: 1,
+    	        value: ''
+    	    });
+    	}
+    	return this.recurrentProcessingNumberField;
+	},
+	
+	getRecurrentProcessingFrequencyCombobox: function() {
+        if(!this.recurrentProcessingFrequencyCombobox) {
+            this.recurrentProcessingFrequencyCombobox = new Ext.form.ComboBox({
+                store: new Ext.data.ArrayStore ({
+					id: 0,
+					fields: ['id', 'value'],
+					data: [
+					    ['DAY', Openwis.i18n('RequestSubscription.SSP.Schedule.RecurrentPeriod.Day')], 
+					    ['HOUR', Openwis.i18n('RequestSubscription.SSP.Schedule.RecurrentPeriod.Hour')]
+					]
+				}),
+				valueField: 'id',
+				displayField:'value',
+    	        value: 'HOUR',
+                name: 'frequencyComboBox',
+                typeAhead: true,
+				mode: 'local',
+				triggerAction: 'all',
+				editable: false,
+				selectOnFocus:true,
+				width: 80
+            });
+        }
+        return this.recurrentProcessingFrequencyCombobox;
+    },
+	
+	//rajout de l'ihm pour saisir date et heure de lancement de tache
+	getStartingDateCompositeField: function() {
+	    if(!this.startingDateCompositeField) {
+    	    this.startingDateCompositeField = new Ext.form.CompositeField({
+    	    	width: 470,
+    			items: 
+    			[
+    			    {
+    			        xtype: 'container',
+    			        style: {
+    			            paddingLeft: '20px'
+    			        }
+    			    },
+    			    new Ext.form.Label({
+        	    		html : Openwis.i18n('RequestSubscription.SSP.Schedule.RecurrentPeriod.StartingAt')
+        	    	}),
+    				this.getStartingDateField(),
+    				this.getStartingDateTimeField()
+    			]
+    		});
+		}
+		return this.startingDateCompositeField;
+	},
+
+    getStartingDateField: function() {
+	    if(!this.startingDateField) {
+    	   this.startingDateField = new Ext.form.DateField({
+                name: 'startingDate',
+                editable: false,
+                format: 'Y-m-d',
+                // Openwis.Utils.Date.ISODateToCalendar(this.frequency.startingDate)
+                value: new Date()
+            });
+        }
+        return this.startingDateField;
+	},
+
+	getStartingDateTimeField: function() {
+		if(!this.startingDateTimeField) {
+	    	this.startingDateTimeField = new Ext.form.TimeField({
+	    		name: 'startingDateTimeField',
+				increment: 15,
+				format: "H:i",
+				// Openwis.Utils.Date.ISODateToTime(this.frequency.startingDate)
+				value: '00:00',
+	    		width: 60
+	    	});
+		}
+        return this.startingDateTimeField;
+	},
+	
 	/**
 	 * The Save action.
 	 */
@@ -623,7 +762,8 @@ Openwis.Admin.Synchro.Manage = Ext.extend(Ext.Window, {
 		task.runMode = {};
 		task.runMode.recurrent = true;
 		if(task.runMode.recurrent) {
-		    var recurrentDay = Ext.num(this.getFrequencyRecurrentDayTextField().getValue(), 0);
+			 /*
+			var recurrentDay = Ext.num(this.getFrequencyRecurrentDayTextField().getValue(), 0);
 		    var recurrentHour = Ext.num(this.getFrequencyRecurrentHourTextField().getValue(), 0);
 		    var recurrentMinute = Ext.num(this.getFrequencyRecurrentMinuteTextField().getValue(), 0);
 		    
@@ -639,6 +779,20 @@ Openwis.Admin.Synchro.Manage = Ext.extend(Ext.Window, {
 		    }
 		    
 		    task.runMode.recurrentPeriod = period;
+		    */
+			var recurrenceValue;
+			var frequencyUnit = this.getRecurrentProcessingFrequencyCombobox().getValue();
+			if (frequencyUnit == "HOUR") {
+				recurrenceValue = this.getRecurrentProcessingNumberField().getValue()*3600;
+			} else {
+				recurrenceValue = this.getRecurrentProcessingNumberField().getValue()*3600*24;
+			}
+				
+			
+		    task.runMode.recurrentScale = this.getRecurrentProcessingFrequencyCombobox().getValue(); 
+		    task.runMode.recurrencePeriod = recurrenceValue;
+		    task.runMode.startingDate = this.getStartingDateField().getValue().format('Y-m-d') + 'T' + this.getStartingDateTimeField().getValue() + ':00Z';
+
 		}
 		
 		//Task configuration.


### PR DESCRIPTION
This is a fix for issue #22 .
If synchronization tasks were created  by the #22 , they must be deleted. They may not be visible in the portal.
Here is a SQL query to get all the synchro tasks:
_select \* from harvestingtask where issynchronization = 'y';_
