### PR TITLE
The database portals initialization query must consider the CITEXT type.

### DIFF
--- a/openwis-metadataportal/openwis-portal/src/main/webapp/WEB-INF/classes/setup/sql/create/create-db-postgres.sql
+++ b/openwis-metadataportal/openwis-portal/src/main/webapp/WEB-INF/classes/setup/sql/create/create-db-postgres.sql
@@ -274,7 +274,7 @@ CREATE TABLE HarvestingTask
 CREATE TABLE Metadata
   (
     id           int,
-    uuid         varchar(250)   not null,
+    uuid         citext   not null,
     schemaId     varchar(32)    not null,
     isTemplate   char(1)        default 'n' not null,
     isHarvested  char(1)        default 'n' not null,
@@ -326,7 +326,7 @@ CREATE TABLE OperationAllowed
 CREATE TABLE DeletedMetadata
   (
     id           int,
-    uuid         varchar(250)   not null,
+    uuid         citext   not null,
     schemaId     varchar(32)    not null,
     category     int            not null,
     deletionDate timestamp without time zone DEFAULT timezone('UTC'::text, now()),


### PR DESCRIPTION
Metadata and DeletedMetadata uuid fields must be CITEXT type (See https://github.com/OpenWIS/openwis/wiki/v3.13:-Deployment-Instructions).
So create-db-postgres.sql updated.
This is a fix for the issue #53 , mandatory to initialize the database on the first run of the portal.
