### PR TITLE
Issue 63: Regression in GISC-DCPC redirection

### DIFF
--- a/openwis-metadataportal/openwis-portal/src/main/webapp/WEB-INF/tags/openwis/requestAction.tag
+++ b/openwis-metadataportal/openwis-portal/src/main/webapp/WEB-INF/tags/openwis/requestAction.tag
@@ -28,7 +28,7 @@
       <%} else { %>
       	doAdhocRequestFromCache("<%=StringEscapeUtils.escapeJavaScript(uuid)%>", "<%= StringEscapeUtils.escapeJavaScript(gtsCategory)%>");<%
       } 
-  } else if (isCacheEnable && StringUtils.isBlank(localDataSource)) {
+  } else if (isCacheEnable && StringUtils.isNotBlank(url)) {
       %>window.open("<%=url%>")<%
    } else {
       if (isBlacklisted) {%>

--- a/openwis-metadataportal/openwis-portal/src/main/webapp/WEB-INF/tags/openwis/subscribeAction.tag
+++ b/openwis-metadataportal/openwis-portal/src/main/webapp/WEB-INF/tags/openwis/subscribeAction.tag
@@ -28,7 +28,7 @@
 	   <%} else { %>
 	   	doSubscriptionFromCache("<%=StringEscapeUtils.escapeJavaScript(uuid)%>", "<%= StringEscapeUtils.escapeJavaScript(gtsCategory) %>", null);<%
 	   }
-   } else if (isCacheEnable && StringUtils.isBlank(localDataSource)) {
+   } else if (isCacheEnable && StringUtils.isNotBlank(url)) {
       %>window.open("<%=url%>")<%
    } else {
       if (isBlacklisted) {%>


### PR DESCRIPTION
Fixed the logic used to determine whether to display a browser window
or the sub-selection dialog for DCPC metadata.  Originally, it made that
decision based on whether the MD references a localDataSource or not.
Now, a browser window is displayed if the MD references a URL which
has either "/retrieve/request/" or "/retrieve/subscribe/" somewhere in
the path (see schema/iso19139/solr-fields.xsl).
