### PR TITLE
Arquillian tests from 3.12  fix

### DIFF
--- a/openwis-dataservice/openwis-dataservice-server/openwis-dataservice-server-ejb/src/test/java/org/openwis/datasource/server/ArquillianDBTestCase.java
+++ b/openwis-dataservice/openwis-dataservice-server/openwis-dataservice-server-ejb/src/test/java/org/openwis/datasource/server/ArquillianDBTestCase.java
@@ -45,10 +45,12 @@ import org.openwis.dataservice.common.domain.entity.subscription.EventBasedFrequ
 import org.openwis.dataservice.common.domain.entity.subscription.Frequency;
 import org.openwis.dataservice.common.domain.entity.subscription.RecurrentFrequency;
 import org.openwis.dataservice.common.domain.entity.subscription.Subscription;
+import org.openwis.dataservice.common.domain.entity.useralarm.UserAlarm;
 import org.openwis.dataservice.common.hash.HashUtils;
 import org.openwis.dataservice.common.util.DateTimeUtils;
 import org.openwis.dataservice.common.util.JndiUtils;
 import org.openwis.dataservice.extraction.ExtractFromCacheImpl;
+import org.openwis.dataservice.useralarms.UserAlarmManagerImpl;
 import org.openwis.dataservice.util.FileInfo;
 import org.openwis.dataservice.util.GTScategory;
 import org.openwis.dataservice.util.GlobalDataCollectionUtils;
@@ -106,7 +108,9 @@ public abstract class ArquillianDBTestCase extends DatabaseTestCase {
                   ProcessedRequestServiceImplTestCase.class.getPackage(),
                   PatternMetadataMapping.class.getPackage(), QueueUtils.class.getPackage(),
                   BlacklistServiceImpl.class.getPackage(),
-                  DisseminatedDataStatisticsImpl.class.getPackage())
+                  DisseminatedDataStatisticsImpl.class.getPackage(),
+                  UserAlarm.class.getPackage(),
+                  UserAlarmManagerImpl.class.getPackage())
             .addManifestResource("test-persistence.xml", "persistence.xml");
 
 


### PR DESCRIPTION
Since the 3.12 version has been modified, some arquillian factory tests written by AKKA do not work:
mvn clean install -Pall -DskipTests=false
=>
Tests in error: 
  testCreateRequest(org.openwis.datasource.server.service.impl.RequestServiceImplTestCase)
  testGetRequest(org.openwis.datasource.server.service.impl.RequestServiceImplTestCase)
  testDeleteRequest(org.openwis.datasource.server.service.impl.RequestServiceImplTestCase)
  testGetLastProcessedRequest(org.openwis.datasource.server.service.impl.RequestServiceImplTestCase)
  testGetRequestsByUsers(org.openwis.datasource.server.service.impl.RequestServiceImplTestCase)
  testRemoveRequest(org.openwis.datasource.server.service.impl.RequestServiceImplTestCase)
  testDeleteSubscription(org.openwis.datasource.server.service.impl.SubscriptionServiceImplTestCase)

We propose this fix.

mvn clean install -Pall -DskipTests=false
=>[INFO] BUILD SUCCESSFUL
