### PR TITLE
Issue 92: Removed two dependencies provided by Jboss

### DIFF
--- a/openwis-dataservice/openwis-dataservice-cache/openwis-dataservice-cache-ejb/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-cache/openwis-dataservice-cache-ejb/pom.xml
@@ -109,6 +109,7 @@
 		<groupId>org.jboss.ejb3</groupId>
 		<artifactId>jboss-ejb3-ext-api</artifactId>
 		<version>1.0.0</version>
+		<scope>provided</scope>
 	</dependency>
     <dependency>
       <groupId>jboss</groupId>

--- a/openwis-dataservice/openwis-dataservice-common/openwis-dataservice-common-domain/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-common/openwis-dataservice-common-domain/pom.xml
@@ -34,12 +34,14 @@
 			<scope>provided</scope>
 		</dependency>
 
+        <!-- 
 		<dependency>
 			<groupId>org.jboss.jbossas</groupId>
 			<artifactId>jboss-as-client</artifactId>
 			<version>5.1.0.GA</version>
 			<type>pom</type>
 		</dependency>
+		 -->
 
       <dependency>
          <groupId>commons-io</groupId>


### PR DESCRIPTION
Removed the jboss-as-client dependency from
openwis-dataservice-common-domain and changed the scope of the
jboss-ejb3-ext-api from compile to provided in
openwis-dataservice-cache-ejb.  Have managed to the data services
deploying again in JBoss AS 5.1

Note: the original stacktrace of this commit was the "Wrong target.
org.jboss.jpa.deployment.PersistenceUnitDeployment" error.  However, the
stacktrace in this issue was also encountered and, I believe, should be
fixed with this commit.
