### PR TITLE
Fixed Issue #98 for dateStamp extraction.

### DIFF
--- a/openwis-metadataportal/openwis-portal/src/main/webapp/xml/schemas/iso19139/extract-import-info.xsl
+++ b/openwis-metadataportal/openwis-portal/src/main/webapp/xml/schemas/iso19139/extract-import-info.xsl
@@ -9,7 +9,7 @@
 				<xsl:value-of select="gmd:fileIdentifier/gco:CharacterString"/>
 			</uuid>
 			<dateStamp>
-				<xsl:value-of select="gmd:dateStamp/gco:DateTime"/>
+				<xsl:value-of select="gmd:dateStamp/gco:DateTime | gmd:dateStamp/gco:Date"/>
 			</dateStamp>
 		</importInfo>
 	</xsl:template>


### PR DESCRIPTION
Modified the XSLT file to search for gco:Date in addition to
gco:DateTime when extracing the value of gmd:dateStamp.

This fix enables openwis to successfully ingest metadata records with
either representation of the dateStamp element.
