### PR TITLE
Updated SOAP URLs in openwis-metadata.properties

### DIFF
--- a/openwis-metadataportal/openwis-portal/src/main/resources/openwis-metadataportal.properties
+++ b/openwis-metadataportal/openwis-portal/src/main/resources/openwis-metadataportal.properties
@@ -1,10 +1,10 @@
 # Data Service WSDLs.
-openwis.metadataportal.dataservice.processedrequestservice.wsdl=http://@dataServiceServer@/openwis-dataservice-openwis-dataservice-server-ejb/ProcessedRequestService?wsdl
-openwis.metadataportal.dataservice.requestservice.wsdl=http://@dataServiceServer@/openwis-dataservice-openwis-dataservice-server-ejb/RequestService?wsdl
-openwis.metadataportal.dataservice.subscriptionservice.wsdl=http://@dataServiceServer@/openwis-dataservice-openwis-dataservice-server-ejb/SubscriptionService?wsdl
-openwis.metadataportal.dataservice.productmetadataservice.wsdl=http://@dataServiceServer@/openwis-dataservice-openwis-dataservice-server-ejb/ProductMetadataService?wsdl
-openwis.metadataportal.dataservice.cacheindexservice.wsdl=http://@dataServiceServer@/openwis-dataservice-openwis-dataservice-cache-ejb/CacheIndex?wsdl
-openwis.metadataportal.dataservice.blacklistservice.wsdl=http://@dataServiceServer@/openwis-dataservice-openwis-dataservice-server-ejb/BlacklistService?wsdl
+openwis.metadataportal.dataservice.processedrequestservice.wsdl=http://@dataServiceServer@/openwis-dataservice-server-ejb/ProcessedRequestService/ProcessedRequestService?wsdl
+openwis.metadataportal.dataservice.requestservice.wsdl=http://@dataServiceServer@/openwis-dataservice-server-ejb/RequestService/RequestService?wsdl
+openwis.metadataportal.dataservice.subscriptionservice.wsdl=http://@dataServiceServer@/openwis-dataservice-server-ejb/SubscriptionService/SubscriptionService?wsdl
+openwis.metadataportal.dataservice.productmetadataservice.wsdl=http://@dataServiceServer@/openwis-dataservice-server-ejb/ProductMetadataService/ProductMetadataService?wsdl
+openwis.metadataportal.dataservice.cacheindexservice.wsdl=http://@dataServiceServer@/openwis-dataservice-cache-ejb/CacheIndexWebService?wsdl
+openwis.metadataportal.dataservice.blacklistservice.wsdl=http://@dataServiceServer@/openwis-dataservice-server-ejb/BlacklistService/BlacklistService?wsdl
 
 # Security service WSDLs.
 openwis.metadataportal.securityservice.usermanagement.wsdl=http://@securityServiceServer@/openwis-securityservice-openwis-securityservice-usermanagement-server-ejb/UserManagementService?wsdl
@@ -17,14 +17,13 @@ openwis.metadataportal.harness.subselectionparameters.wsdl=@subselectionparamete
 openwis.metadataportal.harness.mssfss.wsdl=@mssfss.wsdl@
 
 # Management Service WSDLs
-openwis.management.alertservice.wsdl=http://@managementServiceServer@/openwis-management-service-openwis-management-service-ejb/AlertService?wsdl
-openwis.management.controlservice.wsdl=http://@managementServiceServer@/openwis-management-service-openwis-management-service-ejb/ControlService?wsdl
-openwis.management.monitoringservice.wsdl=http://@managementServiceServer@/openwis-management-service-openwis-management-service-ejb/MonitoringService?wsdl
-openwis.management.disseminateddatastatistics.wsdl=http://@managementServiceServer@/openwis-management-service-openwis-management-service-ejb/DisseminatedDataStatistics?wsdl
-openwis.management.exchangeddatastatistics.statistics.wsdl=http://@managementServiceServer@/openwis-management-service-openwis-management-service-ejb/ExchangedDataStatistics?wsdl
-openwis.management.replicateddatastatistics.wsdl=http://@managementServiceServer@/openwis-management-service-openwis-management-service-ejb/ReplicatedDataStatistics?wsdl
-openwis.management.ingesteddatastatistics.wsdl=http://@managementServiceServer@/openwis-management-service-openwis-management-service-ejb/IngestedDataStatistics?wsdl
-openwis.management.useralarmmanager.wsdl=http://@dataServiceServer@/openwis-dataservice-openwis-dataservice-cache-ejb/UserAlarmManager?wsdl
+openwis.management.alertservice.wsdl=http://@managementServiceServer@/openwis-management-service-ejb/AlertService/AlertService?wsdl
+openwis.management.controlservice.wsdl=http://@managementServiceServer@/openwis-management-service-ejb/ControlService/ControlService?wsdl
+openwis.management.disseminateddatastatistics.wsdl=http://@managementServiceServer@/openwis-management-service-ejb/DisseminatedDataStatistics/DisseminatedDataStatistics?wsdl
+openwis.management.exchangeddatastatistics.statistics.wsdl=http://@managementServiceServer@/openwis-management-service-ejb/ExchangedDataStatistics/ExchangedDataStatistics?wsdl
+openwis.management.replicateddatastatistics.wsdl=http://@managementServiceServer@/openwis-management-service-ejb/ReplicatedDataStatistics/ReplicatedDataStatistics?wsdl
+openwis.management.ingesteddatastatistics.wsdl=http://@managementServiceServer@/openwis-management-service-ejb/IngestedDataStatistics/IngestedDataStatistics?wsdl
+openwis.management.useralarmmanager.wsdl=http://@dataServiceServer@/openwis-dataservice-server-ejb/UserAlarmM
 
 #Support MSS/FSS or not.
 openwis.metadataportal.mssfss.support=@mssfss.support@


### PR DESCRIPTION
Updated the URL path for the SOAP URLs in openwis-metadata.properties to
conform to the URL layout used by JBoss AS 7.1 (previously, these were configured for JBoss AS 5.1).
