### PR TITLE
Added s small Python script to assist in the installation of the data/management services

### DIFF
--- a/openwis-dataservice/openwis-dataservice-config/src/main/config/setup-openwis.cli
+++ b/openwis-dataservice/openwis-dataservice-config/src/main/config/setup-openwis.cli
@@ -23,8 +23,6 @@ batch
 /subsystem=logging/logger=org.openwis.datasource:add(use-parent-handlers=true,handlers=["RequestHandler"])
 /subsystem=logging/logger=org.openwis.management.service:add(use-parent-handlers=true,handlers=["AlertsHandler"])
 
-:reload
-
 
 # Setup the OpenDS data source 
 data-source add --name=OpenwisDS --jndi-name="java:/OpenwisDS" --connection-url="jdbc:postgresql://@openwis.db.host@:@openwis.db.port@/@openwis.db.name@?stringtype=unspecified" --user-name="@openwis.db.username@" --password="@openwis.db.password@" --driver-name="@postgresql.driver.name@" --driver-class="org.postgresql.Driver" --min-pool-size=10 --max-pool-size=40 --idle-timeout-minutes=15 --blocking-timeout-wait-millis=15000 --background-validation-millis=50000 --check-valid-connection-sql="select count(*) from openwis_cache_configuration"


### PR DESCRIPTION
This was in realisation of the amount and complexity of work involved in installing and configuring the data services with JBoss AS 7.1, particularly configuring the JBoss environment.  This script can be executed by the installing user (it's currently only interactive at the moment) to generate baseline configuration property files and a JBoss CLI batch script to setup the environment.

The instructions on how to use the script are in the installation guide published in PR #108.
