### PR TITLE
OpenWIS DataService Updates for JNDI Changes In JBoss EAP 6.4.0

### DIFF
--- a/openwis-dataservice/openwis-dataservice-config/src/main/config/setup-openwis.cli
+++ b/openwis-dataservice/openwis-dataservice-config/src/main/config/setup-openwis.cli
@@ -41,10 +41,10 @@ jms-queue add --queue-address=StatisticsQueue --entries=[queue/StatisticsQueue]
 
 
 # Install the configuration files
-/system-property=conf\/openwis-dataservice:add(value="@openwis.config.dir@/openwis-dataservice.properties")
-/system-property=ws\/localdatasourceservice:add(value="@openwis.config.dir@/localdatasourceservice.properties")
-/subsystem=naming/binding=conf\/openwis-dataservice:add(binding-type=object-factory, module="org.openwis.dataservice.config", class="org.openwis.dataservice.config.PropertiesFactory")
-/subsystem=naming/binding=ws\/localdatasourceservice:add(binding-type=object-factory, module="org.openwis.dataservice.config", class="org.openwis.dataservice.config.PropertiesFactory")
+/system-property=java\:\/conf\/openwis-dataservice:add(value="@openwis.config.dir@/openwis-dataservice.properties")
+/system-property=java\:\/ws\/localdatasourceservice:add(value="@openwis.config.dir@/localdatasourceservice.properties")
+/subsystem=naming/binding=java\:\/conf\/openwis-dataservice:add(binding-type=object-factory, module="org.openwis.dataservice.config", class="org.openwis.dataservice.config.PropertiesFactory")
+/subsystem=naming/binding=java\:\/ws\/localdatasourceservice:add(binding-type=object-factory, module="org.openwis.dataservice.config", class="org.openwis.dataservice.config.PropertiesFactory")
 
 :reload
 run-batch


### PR DESCRIPTION
Newer JBoss versions require that unqualified JNDI bindings become qualified.
The changes offered qualify these JNDI bindings and the associated system properties.
However, although the modifications above appear to work, they are not in compliance with the JNDI binding rules:

Unqualified JNDI bindings must be qualified relative to:
1. java:comp/env
2. java:module/env
3. java:jboss/env

Clarification on this issue is requested.  
Also, could the openwis-dataservice-config JBoss module be discarded were the appropriate namespace used?

https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.2/html-single/Migration_Guide/index.html#sect-JNDI_Changes
