### PR TITLE
Fixed a privilege escalation bug in the registration page

### DIFF
--- a/openwis-metadataportal/openwis-portal/src/main/resources/openwisMessage.properties
+++ b/openwis-metadataportal/openwis-portal/src/main/resources/openwisMessage.properties
@@ -1,6 +1,7 @@
 SelfRegister.subject = Your registration at {0}
 SelfRegister.errorSendingMail = Unable to send the confirmation email; did you filled a valid email address?
 SelfRegister.errorUserExists = The user {0} already exists
+SelfRegister.errorInvalidUser = Invalid user parameters: {1}
 SelfRegister.mailContent = \n Dear User, \n\nYour registration at {0} was successful. \n\n\
 Your account is: \n username : {1} \n password :  {2} \n \n\
 To log in and access your account, please click on the link below.\n {3} \n\n\


### PR DESCRIPTION
The bug allowed clients to adjust the profile field for new users,
creating admin users.  This has been tightened to reject requests that
have profile values other then blank or "user", and also by forcibly
setting the profile of newly created users to User, along with a few
other fields that could be changed explicitly like "quality of service"
class.
