### PR TITLE
Staging Post fix

### DIFF
--- a/openwis-dataservice/openwis-dataservice-cache/openwis-dataservice-cache-core/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-cache/openwis-dataservice-cache-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>openwis-dataservice-cache</artifactId>
     <groupId>io.openwis.dataservice.cache</groupId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/openwis-dataservice/openwis-dataservice-cache/openwis-dataservice-cache-ejb/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-cache/openwis-dataservice-cache-ejb/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>openwis-dataservice-cache</artifactId>
     <groupId>io.openwis.dataservice.cache</groupId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>io.openwis.dataservice.cache</groupId>

--- a/openwis-dataservice/openwis-dataservice-cache/openwis-dataservice-cache-webapp/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-cache/openwis-dataservice-cache-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>openwis-dataservice-cache</artifactId>
     <groupId>io.openwis.dataservice.cache</groupId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/openwis-dataservice/openwis-dataservice-cache/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-cache/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>openwis-dataservice</artifactId>
         <groupId>io.openwis.dataservice</groupId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/openwis-dataservice/openwis-dataservice-common/openwis-dataservice-common-domain/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-common/openwis-dataservice-common-domain/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>openwis-dataservice-common</artifactId>
 		<groupId>io.openwis.dataservice.common</groupId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/openwis-dataservice/openwis-dataservice-common/openwis-dataservice-common-timer/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-common/openwis-dataservice-common-timer/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>openwis-dataservice-common</artifactId>
 		<groupId>io.openwis.dataservice.common</groupId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/openwis-dataservice/openwis-dataservice-common/openwis-dataservice-common-utils/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-common/openwis-dataservice-common-utils/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>openwis-dataservice-common</artifactId>
 		<groupId>io.openwis.dataservice.common</groupId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/openwis-dataservice/openwis-dataservice-common/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>openwis-dataservice</artifactId>
     <groupId>io.openwis.dataservice</groupId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
   

--- a/openwis-dataservice/openwis-dataservice-config/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-config/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>openwis-dataservice</artifactId>
     <groupId>io.openwis.dataservice</groupId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
   

--- a/openwis-dataservice/openwis-dataservice-server/openwis-dataservice-server-ear/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-server/openwis-dataservice-server-ear/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>openwis-dataservice-server</artifactId>
 		<groupId>io.openwis.dataservice.server</groupId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/openwis-dataservice/openwis-dataservice-server/openwis-dataservice-server-ejb/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-server/openwis-dataservice-server-ejb/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>openwis-dataservice-server</artifactId>
 		<groupId>io.openwis.dataservice.server</groupId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/openwis-dataservice/openwis-dataservice-server/openwis-dataservice-server-webapp/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-server/openwis-dataservice-server-webapp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>openwis-dataservice-server</artifactId>
 		<groupId>io.openwis.dataservice.server</groupId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/openwis-dataservice/openwis-dataservice-server/pom.xml
+++ b/openwis-dataservice/openwis-dataservice-server/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>openwis-dataservice</artifactId>
 		<groupId>io.openwis.dataservice</groupId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/openwis-dataservice/pom.xml
+++ b/openwis-dataservice/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.openwis</groupId>
 		<artifactId>openwis</artifactId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/openwis-harness/openwis-harness-client/pom.xml
+++ b/openwis-harness/openwis-harness-client/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.openwis.harness</groupId>
 		<artifactId>openwis-harness</artifactId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/openwis-harness/openwis-harness-dissemination/pom.xml
+++ b/openwis-harness/openwis-harness-dissemination/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>openwis-harness</artifactId>
     <groupId>io.openwis.harness</groupId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>io.openwis.harness</groupId>

--- a/openwis-harness/openwis-harness-localdatasource/pom.xml
+++ b/openwis-harness/openwis-harness-localdatasource/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>openwis-harness</artifactId>
     <groupId>io.openwis.harness</groupId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>io.openwis.harness</groupId>

--- a/openwis-harness/openwis-harness-mssfss/pom.xml
+++ b/openwis-harness/openwis-harness-mssfss/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>openwis-harness</artifactId>
     <groupId>io.openwis.harness</groupId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>io.openwis.harness</groupId>

--- a/openwis-harness/openwis-harness-subselectionparameters/pom.xml
+++ b/openwis-harness/openwis-harness-subselectionparameters/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>openwis-harness</artifactId>
     <groupId>io.openwis.harness</groupId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>io.openwis.harness</groupId>

--- a/openwis-harness/pom.xml
+++ b/openwis-harness/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.openwis</groupId>
 		<artifactId>openwis</artifactId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<groupId>io.openwis.harness</groupId>

--- a/openwis-management/openwis-management-client/pom.xml
+++ b/openwis-management/openwis-management-client/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>openwis-management</artifactId>
 		<groupId>io.openwis.management</groupId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/openwis-management/openwis-management-service/openwis-management-service-common/pom.xml
+++ b/openwis-management/openwis-management-service/openwis-management-service-common/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>openwis-management-service</artifactId>
 		<groupId>io.openwis.management.service</groupId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/openwis-management/openwis-management-service/openwis-management-service-ear/pom.xml
+++ b/openwis-management/openwis-management-service/openwis-management-service-ear/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>openwis-management-service</artifactId>
 		<groupId>io.openwis.management.service</groupId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/openwis-management/openwis-management-service/openwis-management-service-ejb/pom.xml
+++ b/openwis-management/openwis-management-service/openwis-management-service-ejb/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>openwis-management-service</artifactId>
 		<groupId>io.openwis.management.service</groupId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/openwis-management/openwis-management-service/pom.xml
+++ b/openwis-management/openwis-management-service/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>openwis-management</artifactId>
     <groupId>io.openwis.management</groupId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/openwis-management/pom.xml
+++ b/openwis-management/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.openwis</groupId>
     <artifactId>openwis</artifactId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/openwis-metadataportal/cachingxslt/pom.xml
+++ b/openwis-metadataportal/cachingxslt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
   

--- a/openwis-metadataportal/jeeves/pom.xml
+++ b/openwis-metadataportal/jeeves/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
   

--- a/openwis-metadataportal/oaipmh/pom.xml
+++ b/openwis-metadataportal/oaipmh/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
   

--- a/openwis-metadataportal/openwis-portal-solr/pom.xml
+++ b/openwis-metadataportal/openwis-portal-solr/pom.xml
@@ -4,7 +4,7 @@
 	   <parent>
 		  <groupId>org.geonetwork-opensource</groupId>
 		  <artifactId>geonetwork</artifactId>
-		  <version>3.14.2</version>
+		  <version>3.14.2-SNAPSHOT</version>
 		  <relativePath>../pom.xml</relativePath>
 	   </parent>
 

--- a/openwis-metadataportal/openwis-portal/pom.xml
+++ b/openwis-metadataportal/openwis-portal/pom.xml
@@ -5,7 +5,7 @@
    <parent>
       <groupId>org.geonetwork-opensource</groupId>
       <artifactId>geonetwork</artifactId>
-	  <version>3.14.2</version>
+	  <version>3.14.2-SNAPSHOT</version>
 	  <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/openwis-metadataportal/pom.xml
+++ b/openwis-metadataportal/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.openwis</groupId>
 		<artifactId>openwis</artifactId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	
@@ -25,7 +25,7 @@
       scm:svn:https://geonetwork.svn.sourceforge.net/svnroot/geonetwork/trunk
     </connection>
     <url>https://geonetwork.svn.sourceforge.net/svnroot/geonetwork/trunk</url>
-    <tag>openwis-3.14.2-release</tag>
+    <tag>HEAD</tag>
   </scm>
   
   <!-- =========================================================== -->

--- a/openwis-metadataportal/sde/pom.xml
+++ b/openwis-metadataportal/sde/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.geonetwork-opensource</groupId>
     <artifactId>geonetwork</artifactId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
   </parent>
   

--- a/openwis-portal-client/pom.xml
+++ b/openwis-portal-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.openwis</groupId>
 		<artifactId>openwis</artifactId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/openwis-securityservice/openwis-securityservice-utils/PopulateLDAP/pom.xml
+++ b/openwis-securityservice/openwis-securityservice-utils/PopulateLDAP/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.openwis.securityservice.utils</groupId>
 		<artifactId>openwis-securityservice-utils</artifactId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/openwis-securityservice/openwis-securityservice-utils/pom.xml
+++ b/openwis-securityservice/openwis-securityservice-utils/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>openwis-securityservice</artifactId>
 		<groupId>io.openwis.securityservice</groupId>		
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/openwis-securityservice/openwis-securityservice-war/pom.xml
+++ b/openwis-securityservice/openwis-securityservice-war/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>openwis-securityservice</artifactId>
         <groupId>io.openwis.securityservice</groupId>
-        <version>3.14.2</version>
+        <version>3.14.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/openwis-securityservice/pom.xml
+++ b/openwis-securityservice/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>io.openwis</groupId>
 		<artifactId>openwis</artifactId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	

--- a/openwis-stagingpost/pom.xml
+++ b/openwis-stagingpost/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>openwis</artifactId>
 		<groupId>io.openwis</groupId>
-		<version>3.14.2</version>
+		<version>3.14.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	
 	<groupId>io.openwis</groupId>
 	<artifactId>openwis</artifactId>
-	<version>3.14.2</version>
+	<version>3.14.2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>OpenWIS</name>
    
@@ -14,7 +14,7 @@
    <scm>
       <connection>scm:git:git@github.com:OpenWIS/openwis.git</connection>
       <developerConnection>scm:git:git@github.com:OpenWIS/openwis.git</developerConnection>
-	  <tag>openwis-3.14.2-release</tag>
+	  <tag>HEAD</tag>
       <url>https://github.com/OpenWIS/openwis</url>
    </scm>
    


### PR DESCRIPTION
HI Leon,

I'd like to get this one in 3.14.3. I noticed it again when scripting the puppet environments at the Met Office and this issue fixes the problem. I had initially scripted around it but this is a better solution to removed the hardocded path in the web.xml re #71 

It also means not having to update the path in this file in the future as it's using the context relative to the staging post deployment

Cheers,

Martin
