### PR TITLE
Option 2 Fix in issue in issue #71

### DIFF
--- a/openwis-stagingpost/src/main/webapp/WEB-INF/web.xml
+++ b/openwis-stagingpost/src/main/webapp/WEB-INF/web.xml
@@ -22,8 +22,8 @@
       </init-param>
       
       <init-param>
-         <param-name>globalXsltFile</param-name>
-         <param-value>/var/opt/openwis/stagingPost/WEB-INF/globalXsltFile.xsl</param-value>
+         <param-name>contextXsltFile</param-name>
+         <param-value>WEB-INF/globalXsltFile.xsl</param-value>
       </init-param>
 
       <load-on-startup>1</load-on-startup>


### PR DESCRIPTION
HI Leon,

I'd like to get this one in 3.14.3. I noticed it again when scripting the puppet environments at the Met Office and this issue fixes the problem. I had initially scripted around it but this is a better solution to removed the hardocded path in the web.xml re #71

It also means not having to update the path in this file in the future as it's using the context relative to the staging post deployment

Cheers,

Martin
