### PR TITLE
Added the archived Codehaus repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,13 @@
 		<id>repo1-maven2</id>
 		<url>http://repo1.maven.org/maven2</url>
 	  </repository>
+
+      <!-- Repository hosting artefacts formally hosted by Codehaus (which was shutdown): http://www.codehaus.org/mechanics/maven/ -->
+      <repository>
+        <id>codehaus-mule-repo</id>
+        <url>https://repository-master.mulesoft.org/nexus/content/groups/public/</url>
+        <layout>default</layout>
+      </repository>
 	</repositories>
   
 


### PR DESCRIPTION
This was based on the instructions published by Codehaus, which has
since shut-down.  Instructions are located here:
http://www.codehaus.org/mechanics/maven/

This relates to issue #153.
