### PR TITLE
issue-169: fixed dependency issues in load-test-data

### DIFF
--- a/openwis-tools/load-test-data/pom.xml
+++ b/openwis-tools/load-test-data/pom.xml
@@ -99,14 +99,24 @@
 					<target>1.7</target>
 				</configuration>
 			</plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <configuration>
-                    <mainClass>io.openwis.tools.loadtestdata.LoadTestData</mainClass>
-                </configuration>
-            </plugin>
 		</plugins>
 	</build>
+	
+	<profiles>
+		<profile>
+			<id>openwis</id>
+			<build>
+				<plugins>
+		            <plugin>
+		                <groupId>org.codehaus.mojo</groupId>
+		                <artifactId>exec-maven-plugin</artifactId>
+		                <configuration>
+		                    <mainClass>io.openwis.tools.loadtestdata.LoadTestData</mainClass>
+		                </configuration>
+		            </plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -135,13 +135,16 @@
                <groupId>org.codehaus.mojo</groupId>
                <artifactId>exec-maven-plugin</artifactId>
                <version>1.2.1</version>
+               <inherited>false</inherited>
 			   <executions>
 					<execution>
 					<id>install-javaee-jar</id>
+                    <!--
 					<phase>install</phase>
 					<goals>
 						<goal>exec</goal>
 					</goals>
+                    -->
 					</execution>
 				</executions>
 				<configuration>


### PR DESCRIPTION
load-test-data was previously using slf4j for logging, which was not
declared in the POM file.  Removed that dependency from that project.

Also fixed a config bug which was causing Maven build issues for the
load-test-data project due to the inherited configuration of the
exec:exec plugin.  The plugin was executing during the install goal,
attempting to install a j2ee dependency which was not present in the
project.
