### PR TITLE
Fix for Issue 166

### DIFF
--- a/openwis-metadataportal/openwis-portal/src/main/java/org/fao/geonet/kernel/DataManager.java
+++ b/openwis-metadataportal/openwis-portal/src/main/java/org/fao/geonet/kernel/DataManager.java
@@ -2545,15 +2545,16 @@ public class DataManager implements IndexListener {
          if (aNs.getPrefix().equals("")) { // found default namespace
             String prefix = mds.getPrefix(aNs.getURI());
             if (prefix == null) {
-               throw new IllegalArgumentException(
+            	Log.warning(Geonet.DATA_MANAGER,
                      "No prefix - cannot find a namespace to set for element "
                            + md.getQualifiedName() + " - namespace URI " + aNs.getURI());
-            }
-            ns = Namespace.getNamespace(prefix, aNs.getURI());
-            setNamespacePrefix(md, ns);
-            if (!md.getNamespace().equals(ns)) {
-               md.removeNamespaceDeclaration(aNs);
-               md.addNamespaceDeclaration(ns);
+            } else {
+            	ns = Namespace.getNamespace(prefix, aNs.getURI());
+	            setNamespacePrefix(md, ns);
+	            if (!md.getNamespace().equals(ns)) {
+	               md.removeNamespaceDeclaration(aNs);
+	               md.addNamespaceDeclaration(ns);
+	            }
             }
          }
       }


### PR DESCRIPTION
The fix is to allow default XML namespace if it is not part of the
ISO19139 namespaces (e.g. OAI-PMH namespace). A warning message is
inserted into the log file when this happens.
