### PR TITLE
Lock OpenJDK in Vagrant to 1.7.0.101-2.6.6.4

### DIFF
--- a/resources/vagrant/provisioning/provision-db.sh
+++ b/resources/vagrant/provisioning/provision-db.sh
@@ -108,7 +108,11 @@ sudo -iu openwis mkdir "$openwisOpt"
 sudo -iu openwis mkdir "$openwisHome/staging"
 
 #echo "Unpacking Java"
-yum install -y java-1.7.0-openjdk-devel.x86_64
+# Install latest available JDK (seems to break installation after 1.7.0.101-2.6.6.4)
+# yum install -y java-1.7.0-openjdk-devel.x86_64
+
+# Install latest compatible JDK (still available in YUM).
+yum install -y java-1.7.0-openjdk-devel-1.7.0.101-2.6.6.4.el6_8
 
 echo "Unpacking Tomcat"
 sudo -iu openwis wget -q -O /tmp/apache-tomcat.tar.gz "$RESOURCE_TOMCAT"

--- a/resources/vagrant/provisioning/provision-portals.sh
+++ b/resources/vagrant/provisioning/provision-portals.sh
@@ -39,7 +39,11 @@ tomcatHome="$openwisHome/`basename "$RESOURCE_TOMCAT" .tar.gz`"
 sudo -iu openwis mkdir "$openwisOpt"
 sudo -iu openwis mkdir "$openwisHome/staging"
 
-yum install -y java-1.7.0-openjdk-devel.x86_64
+# Install latest available JDK (seems to break installation after 1.7.0.101-2.6.6.4)
+# yum install -y java-1.7.0-openjdk-devel.x86_64
+
+# Install latest compatible JDK (still available in YUM).
+yum install -y java-1.7.0-openjdk-devel-1.7.0.101-2.6.6.4.el6_8
 
 #echo "Unpacking Java"
 #sudo -iu openwis tar -xvz -C "$openwisOpt" -f /vagrant/dependencies/jdk-7u51-linux-x64.tar.gz

--- a/resources/vagrant/provisioning/setup-openwis-using-jboss7.sh
+++ b/resources/vagrant/provisioning/setup-openwis-using-jboss7.sh
@@ -43,7 +43,12 @@ function owConf()
 
 # 1. As root, install the OpenJDK 1.7 Devel package from the Red Hat Repositories.
 #
-yum install -y java-1.7.0-openjdk-devel.x86_64
+# Install latest available JDK (seems to break installation after 1.7.0.101-2.6.6.4)
+# yum install -y java-1.7.0-openjdk-devel.x86_64
+
+# Install latest compatible JDK (still available in YUM).
+yum install -y java-1.7.0-openjdk-devel-1.7.0.101-2.6.6.4.el6_8
+
 
 # 2. As openwis, download and install JBoss AS 7.1 community edition from jboss.org.
 #


### PR DESCRIPTION
Vagrant provisioning scripts install the latest OpenJDK version using:
`yum install -y java-1.7.0-openjdk-devel.x86_64`
The above, currently, installs 1.7.0.111-2.6.7.2 which seems to create some Java security issues when booting up Tomcat (or configuring JBoss with its CLI) rendering portals unusable.

The version specified in Puppet scripts, 1.7.0.19-2.3.9.1, isn't available in YUM and requires manual installation via RPM. A quick fix is to switch to the just previously available version 1.7.0.101-2.6.6.4. This PR does exactly that by modifying the provisioning scripts.

_Note: In some time in the future 1.7.0.101-2.6.6.4 will also become unavailable in YUM. Until then, we need to resolve the security issue facing when using more recent JDKs, so that we can revert back to `yum install -y java-1.7.0-openjdk-devel.x86_64`._
