### PR TITLE
issue-192: downgraded the version of Java 7 used by vagrant data

### DIFF
--- a/resources/vagrant/provisioning/setup-openwis-using-jboss7.sh
+++ b/resources/vagrant/provisioning/setup-openwis-using-jboss7.sh
@@ -43,7 +43,8 @@ function owConf()
 
 # 1. As root, install the OpenJDK 1.7 Devel package from the Red Hat Repositories.
 #
-yum install -y java-1.7.0-openjdk-devel.x86_64
+#yum install -y java-1.7.0-openjdk-devel.x86_64
+yum install -y java-1.7.0-openjdk-1.7.0.101
 
 # 2. As openwis, download and install JBoss AS 7.1 community edition from jboss.org.
 #


### PR DESCRIPTION
The JBoss CLI was experiencing InternalError exceptions when executing
commands during initialisation.  This was a recent incident and is
suspected to be associated with the version of OpenJDK being installed.
Downgrading OpenJDK to 1.7.0.101 seemed to have resolved the problem.
