### PR TITLE
Reconfig of vagrant to disable swapping of SSH keys

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,8 @@ Vagrant.configure(2) do |config|
   # boxes at https://atlas.hashicorp.com/search.
   config.vm.box = "sinergi/centos-65-x64"
 
+  config.ssh.insert_key = false
+
   # The DB services
   config.vm.define "db" do |db|
     db.vm.hostname = "owdev-db"


### PR DESCRIPTION
Reconfigured Vagrant to disable the swapping of the public insecure SSH
key with a generated secure one.  This is due to some failures to
authenticate in time on some host machines, causing Vagrant to abandon
provisioning the VMs.  Since these VMs are development only, this, to
me, is considered safe.
