### PR TITLE
ISSUE #315 Populate LDAP  Error

### DIFF
--- a/openwis-securityservice/openwis-securityservice-war/src/main/resources/openwis-securityservice.properties
+++ b/openwis-securityservice/openwis-securityservice-war/src/main/resources/openwis-securityservice.properties
@@ -5,6 +5,7 @@
 # LDAP Host
 ldap_host=@ldap.host@
 ldap_port=1389
+ldap_ssl=false
 ldap_user=cn=Directory Manager
 ldap_password=@ldap.password@
 global_groups=Institutional


### PR DESCRIPTION
Populate LDAP Initialize Deployment Error
Can't find resource for bundle java.util.PropertyResourceBundle, key ldap_ssl 
Added "ldap_ssl=false" to file openwis-securityservice.properties for the deployment WAR.